### PR TITLE
refactor borgmatic config generation

### DIFF
--- a/roles/borgmatic/tasks/config.yml
+++ b/roles/borgmatic/tasks/config.yml
@@ -1,65 +1,9 @@
-- name: Get config vars
-  set_fact:
-    borgmatic_location_vars: "{{ lookup('varnames', '^borgmatic_location_') }}"
-    borgmatic_storage_vars: "{{ lookup('varnames', '^borgmatic_storage_') }}"
-    borgmatic_retention_vars: "{{ lookup('varnames', '^borgmatic_retention_') }}"
-    borgmatic_consistency_vars: "{{ lookup('varnames', '^borgmatic_consistency_') }}"
-    borgmatic_hooks_vars: "{{ lookup('varnames', '^borgmatic_hooks_') }}"
-    borgmatic_config: {}
-    borgmatic_retention_keeps: "{{ lookup('varnames', '^borgmatic_retention_keep_') }}"
-
-- name: Verify that at least one keep option is set
-  assert:
-    that:
-      - borgmatic_retention_keeps is string
-      - borgmatic_retention_keeps | length > 0
-
-# TODO: Use an inner loop to simplify config generation
-- block: # noqa unnamed-task
-    - name: Generate borgmatic config [location]
-      set_fact:
-        borgmatic_location: "{{ borgmatic_location | default({}) | combine({ ( item | replace('borgmatic_location_', '')): lookup('vars', item) }) }}"
-      loop: "{{ borgmatic_location_vars.split(',') }}"
-    - name: Update global config
-      set_fact:
-        borgmatic_config: "{{ borgmatic_config | combine({ 'location': borgmatic_location }) }}"
-  when: borgmatic_location_vars is string
-- block: # noqa unnamed-task
-    - name: Generate borgmatic config [storage]
-      set_fact:
-        borgmatic_storage: "{{ borgmatic_storage | default({}) | combine({ ( item | replace('borgmatic_storage_', '')): lookup('vars', item) }) }}"
-      loop: "{{ borgmatic_storage_vars.split(',') }}"
-    - name: Update global config
-      set_fact:
-        borgmatic_config: "{{ borgmatic_config | combine({ 'storage': borgmatic_storage }) }}"
-  when: borgmatic_storage_vars is string
-- block: # noqa unnamed-task
-    - name: Generate borgmatic config [retention]
-      set_fact:
-        borgmatic_retention: "{{ borgmatic_retention | default({}) | combine({ ( item | replace('borgmatic_retention_', '')): lookup('vars', item) }) }}"
-      loop: "{{ borgmatic_retention_vars.split(',') }}"
-    - name: Update global config
-      set_fact:
-        borgmatic_config: "{{ borgmatic_config | combine({ 'retention': borgmatic_retention }) }}"
-  when: borgmatic_retention_vars is string
-- block: # noqa unnamed-task
-    - name: Generate borgmatic config [consistency]
-      set_fact:
-        borgmatic_consistency: "{{ borgmatic_consistency | default({}) | combine({ ( item | replace('borgmatic_consistency_', '')): lookup('vars', item) }) }}"
-      loop: "{{ borgmatic_consistency_vars.split(',') }}"
-    - name: Update global config
-      set_fact:
-        borgmatic_config: "{{ borgmatic_config | combine({ 'consistency': borgmatic_consistency }) }}"
-  when: borgmatic_consistency_vars is string
-- block: # noqa unnamed-task
-    - name: Generate borgmatic config [hooks]
-      set_fact:
-        borgmatic_hooks: "{{ borgmatic_hooks | default({}) | combine({ ( item | replace('borgmatic_hooks_', '')): lookup('vars', item) }) }}"
-      loop: "{{ borgmatic_hooks_vars.split(',') }}"
-    - name: Update global config
-      set_fact:
-        borgmatic_config: "{{ borgmatic_config | combine({ 'hooks': borgmatic_hooks }) }}"
-  when: borgmatic_hooks_vars is string
+- name: Generate config variables # noqa var-spacing
+  ansible.builtin.set_fact:
+    # -> dict of config var name and actual value
+    _borgmatic_configvars: "{{ _borgmatic_configvars | d({}) | combine({ item: lookup('vars', item )} ) }}"
+  # -> List of all variable names that we need to lookup for our config
+  loop: "{{ query('varnames', '^borgmatic_(' + borgmatic_config_sections | join('|') + ')_') }}"
 
 - name: Config is installed
   template:

--- a/roles/borgmatic/tasks/main.yml
+++ b/roles/borgmatic/tasks/main.yml
@@ -9,6 +9,10 @@
       - borgmatic_location_repositories is defined
       - borgmatic_location_repositories | length > 0
   when: borgmatic_manage_config
+- name: Verify that at least one keep option is set
+  assert:
+    that: query('varnames', '^borgmatic_retention_keep_') | length > 0
+  when: borgmatic_manage_config
 
 - ansible.builtin.include_tasks: install.yml
   when: borgmatic_install

--- a/roles/borgmatic/templates/config.yaml.j2
+++ b/roles/borgmatic/templates/config.yaml.j2
@@ -1,4 +1,20 @@
-# Borgmatic main configuration file
-# Managed by Ansible - do not modify
+#jinja2: trim_blocks: False
 
-{{ borgmatic_config | to_nice_yaml(indent=2, width=120) }}
+# Borgmatic main configuration file
+# {{ ansible_managed }}
+
+{%- set config = {} %}
+{%- for section in borgmatic_config_sections %}
+    {%- set section_cfg = {} %}
+    {%- for entry in _borgmatic_configvars %}
+        {%- if entry is match('^borgmatic_' + section + '_') %}
+            {%- set entry_name = entry.replace('borgmatic_' + section + '_', '') %}
+            {#- Really nasty way to update a dict in jinja, but i don't know of a cleaner way to accomplish this #}
+            {%- set _ = section_cfg.update({entry_name: _borgmatic_configvars[entry]}) %}
+        {%- endif %}
+    {%- endfor %}
+    {%- if section_cfg | length > 0 %}
+        {%- set _ = config.update({section: section_cfg}) %}
+    {%- endif %}
+{%- endfor %}
+{{ config | to_nice_yaml(indent=2, width=120) }}

--- a/roles/borgmatic/vars/main.yml
+++ b/roles/borgmatic/vars/main.yml
@@ -1,0 +1,6 @@
+borgmatic_config_sections:
+  - location
+  - storage
+  - retention
+  - consistency
+  - hooks


### PR DESCRIPTION
This refactor aims to reduce the repetition and output verbosity
when generating the borgmatic configuration file.
Most of the code in config.yml is replaced by a slightly more elaborate
config template, but it is still much more readable than the old code