### PR TITLE
Remove Ubuntu 18 support, add Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Dependencies
 
-- A recent version of ansible. We test against the current and the previous major releases
+- A recent version of ansible. We test against the current and the 2 previous major releases
 - Python 3.6 or newer on remote hosts and the controller
 
 ### Install via ansible-galaxy

--- a/roles/borg_server/README.md
+++ b/roles/borg_server/README.md
@@ -9,8 +9,8 @@ The server uses these keys to restrict hosts into a single directory where they 
 ## Requirements
 
 - The following distributions are currently supported:
-  - Ubuntu 18.04 LTS or newer
-  - Debian 10 or newer
+  - Ubuntu: 20.04 LTS, 22.04 LTS
+  - Debian: 10, 11, 12
   - There are no plans to support CentOS/RHEL-based distros right now
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 

--- a/roles/borg_server/molecule/default/molecule.yml
+++ b/roles/borg_server/molecule/default/molecule.yml
@@ -16,10 +16,10 @@ platforms:
     pre_build_image: true
     systemd: always
 
-  - name: borg-server-ubuntu-18
+  - name: borg-server-debian-12
     groups:
-      - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     override_command: false
     pre_build_image: true
     systemd: always

--- a/roles/borgmatic/README.md
+++ b/roles/borgmatic/README.md
@@ -13,8 +13,8 @@ then optionally sets up a scheduled backup job. More specifically, this role wil
 ## Requirements
 
 - The following distributions are currently supported:
-  - Ubuntu 20.04 LTS or newer
-  - Debian 11 or newer
+  - Ubuntu: 20.04 LTS, 22.04 LTS
+  - Debian: 11, 12
   - There are no plans to support CentOS/RHEL-based distros right now
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 - Supported Borgmatic versions: 1.5 and up

--- a/roles/borgmatic/molecule/default/molecule.yml
+++ b/roles/borgmatic/molecule/default/molecule.yml
@@ -16,6 +16,14 @@ platforms:
     pre_build_image: true
     systemd: always
 
+  - name: borgmatic-debian-12
+    groups:
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
+    override_command: false
+    pre_build_image: true
+    systemd: always
+
   - name: borgmatic-debian-11
     groups:
       - debian

--- a/roles/borgmatic/molecule/remote-repo/molecule.yml
+++ b/roles/borgmatic/molecule/remote-repo/molecule.yml
@@ -20,6 +20,16 @@ platforms:
     systemd: always
     network: molecule-borgmatic
 
+  - name: borgmatic-debian-12
+    groups:
+      - debian
+      - clients
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
+    override_command: false
+    pre_build_image: true
+    systemd: always
+    network: molecule-borgmatic
+
   - name: borgmatic-debian-11
     groups:
       - debian


### PR DESCRIPTION
Now that Ubuntu 18.04 LTS has reached its mainline EOL, we can drop it from the list of supported distributions. At the same time, Debian 12 has been added to the distro list and the READMEs now explicitly list the supported versions to prevent confusion when new imcompatible major distro versions are released. 