### PR TITLE
Add conditional on installation of the config.yml

### DIFF
--- a/roles/borgmatic/tasks/main.yml
+++ b/roles/borgmatic/tasks/main.yml
@@ -39,6 +39,7 @@
         owner: root
         group: root
         mode: "640"
+      when: borgmatic_manage_config
 
     - name: Initialize repos
       command: "borgmatic init --encryption {{ borgmatic_init_encryption }}"


### PR DESCRIPTION
When using the extension with the following options and the config file is created when it probably should not. Unfortunately, this configuration results in the creation of a mostly empty config.yaml that fails at the Initialize repos step. Would it be acceptable to add when: borgmatic_manage_config as in the following block to avoid the extra file from getting created?

```yaml
borgmatic_setup_backup: true
borgmatic_manage_config: false
```
Unfortunately, this configuration results in the creation of a mostly empty config.yaml that fails at the Initialize repos step. This PR ads `when: borgmatic_manage_config` to avoid the extra file from getting created when the file is not expected to be managed.

Closes #179 