### PR TITLE
bump ansible to 2.17, raise minimum python to 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ workflows:
           parallelism: 3
           matrix:
             parameters:
-              ansible-version: ["2.15", "2.16"]
-              node-python-version: ["3.6"]
+              ansible-version: ["2.16", "2.17"]
+              node-python-version: ["3.7"]
       - collection-testing/pre-commit-lint:
           name: Lint
       - collection-testing/publish-github:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Dependencies
 
 - A recent version of ansible. We test against the current and the previous major release
-- Python 3.6 or newer on remote hosts and the controller
+- Python 3.7 or newer on remote hosts and the controller
 
 ### Install via ansible-galaxy
 


### PR DESCRIPTION
With the ansible-2.17 release, python 2 and 3.6 have been removed
from the officially supported list. We therefore have to upgrade
our minimum tested version to 3.7, which is a breaking change,
even if we are not planning on breaking support ourselves.