### PR TITLE
Add support for append-only keys

### DIFF
--- a/roles/borg_server/README.md
+++ b/roles/borg_server/README.md
@@ -53,6 +53,7 @@ The server uses these keys to restrict hosts into a single directory where they 
       key: ssh-rsa key-goes-here
     - name: host2.my.domain
       key: ssh-rsa key-goes-here
+      append_only: true
     ...
   ```
 
@@ -69,4 +70,5 @@ The server uses these keys to restrict hosts into a single directory where they 
             key: ssh-rsa key-goes-here
           - name: host2.my.domain
             key: ssh-rsa key-goes-here
+            append_only: true
 ```

--- a/roles/borg_server/README.md
+++ b/roles/borg_server/README.md
@@ -45,6 +45,7 @@ The server uses these keys to restrict hosts into a single directory where they 
 ##### `borg_server_authorized_hosts`
 - List of hosts that will have access to the backup server
 - Each entry is a dict containing the host name and its ssh public key
+    - You can optionally specify `append_only` to run in [Append-only mode](https://borgbackup.readthedocs.io/en/stable/usage/notes.html#append-only-mode-forbid-compaction)
 - Required: yes
 - Example:
   ```yaml

--- a/roles/borg_server/molecule/default/converge.yml
+++ b/roles/borg_server/molecule/default/converge.yml
@@ -11,3 +11,6 @@
         borg_server_authorized_hosts:
           - name: "test-host.localdomain"
             key: "{{ lookup('file', 'files/id_rsa.pub') }}"
+          - name: "test-append.localdomain"
+            key: "{{ lookup('file', 'files/id_rsa.pub') }}"
+            append_only: yes

--- a/roles/borg_server/molecule/default/verify.yml
+++ b/roles/borg_server/molecule/default/verify.yml
@@ -19,7 +19,8 @@
     - name: Verify that key is present
       assert:
         that:
-          - "'cd /var/borg-server-molecule/test-host.localdomain; borg serve --restrict-to-path /var/borg-server-molecule/test-host.localdomain' in borg_server_authorized_keys.stdout"
+          - "'cd /var/borg-server-molecule/test-host.localdomain; borg serve --restrict-to-path /var/borg-server-molecule/test-host.localdomain\"' in borg_server_authorized_keys.stdout"
+          - "'cd /var/borg-server-molecule/test-append.localdomain; borg serve --restrict-to-path /var/borg-server-molecule/test-append.localdomain --append-only\"' in borg_server_authorized_keys.stdout"
           - "'restrict ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDDyaA8lzdTJ7BCfINstM1IycLC7ghbVEz0reGj8v+s0+/+ltryuUNqrfVqud2vWhWWRsdW5l9c0RKESPEkReqe5qmzfArS1DicDjbS4O8ekhd4p2SgzFSRRm31W0C5KDnusc9f4xGenO4lKZW+AQ5qbQAoFr1l+6HyQU/7GRg0hcSN6obQwURIFj2SjsEav0Vv8BL9KkPG4p85YGiWxaNwsgmrNSx2qQjPFgKYUftF0oV4kCGIF8WdL5rwofGtHuCD7C7+8uKn4x7t6XetP8cti325y7LTlXcxe+OHJen0GhLAu4+u3q+z0uQipbiUMx3KhDDKMdM/kNrEtBkkCp0GQ+9yOT4Th9xK5ICX8LFIPWooCciF1vfNgF7y/UWdxtfX6d1aGqUchlSC1sh2NqvZujc04/3EzNtkZiulFBWLWAxwDMNgprL0OiPpwyGLqJILqizBt4MW7cTd73hZR6kSkmpkTupszWfbfa+g/qS35sMjcxJqzUbpOFE4V9cKeE0= molecule' in borg_server_authorized_keys.stdout"
 
     - name: Look for dirty file

--- a/roles/borg_server/templates/authorized_keys.j2
+++ b/roles/borg_server/templates/authorized_keys.j2
@@ -1,3 +1,4 @@
 {% for host in borg_server_authorized_hosts %}
-command="cd {{ borg_server_backups_path }}/{{ host.name }}; borg serve --restrict-to-path {{ borg_server_backups_path }}/{{ host.name }}",restrict {{ host.key }}
+{% set append_only = " --append-only" if (host.append_only is defined and host.append_only | bool) else '' %}
+command="cd {{ borg_server_backups_path }}/{{ host.name }}; borg serve --restrict-to-path {{ borg_server_backups_path }}/{{ host.name }}{{ append_only }}",restrict {{ host.key }}
 {% endfor %}

--- a/roles/borg_server/templates/authorized_keys.j2
+++ b/roles/borg_server/templates/authorized_keys.j2
@@ -1,4 +1,4 @@
 {% for host in borg_server_authorized_hosts %}
-{% set append_only = " --append-only" if (host.append_only is defined and host.append_only | bool) else '' %}
+{% set append_only = " --append-only" if (host.append_only | d(false)) else '' %}
 command="cd {{ borg_server_backups_path }}/{{ host.name }}; borg serve --restrict-to-path {{ borg_server_backups_path }}/{{ host.name }}{{ append_only }}",restrict {{ host.key }}
 {% endfor %}


### PR DESCRIPTION
To not get all backups deleted by some ransomware or something, I want to serve the repositories in append-only mode (as proposed by [borg documentation](https://borgbackup.readthedocs.io/en/stable/usage/notes.html#append-only-mode-forbid-compaction)).

I added an assertion to the molecules tests, but as I don't have Docker, I couldn't run them. I hope that CI will do this for me :)

To make sure that there is no `--append-only` in the [`test-host` case](https://github.com/maxhoesel-ansible/ansible-collection-borgbackup/compare/main...Jonny007-MKD:ansible-collection-borgbackup:main#diff-d463b936ba39ef7c5353f84cd588ce4873d698a61770a492460a9c6dd2f809dbR22), I appended a `\"` to make sure that the generated command ends as expected.