### PR TITLE
Use ansible_host and ansible_port for ssh-keyscan

### DIFF
--- a/roles/borgmatic/tasks/config_ssh_known_hosts.yml
+++ b/roles/borgmatic/tasks/config_ssh_known_hosts.yml
@@ -17,7 +17,7 @@
 # can understand. I'm sure there is an easier way to do this, but this works for now
 # and doesn't throw up and idempotency issues
 - name: Get remote server ssh fingerprints
-  command: "ssh-keyscan {{ item }}"
+  command: "ssh-keyscan -p {{ hostvars[item].ansible_port | d(22) }} {{ hostvars[item].ansible_host | d(item) }}"
   changed_when: no
   check_mode: no
   retries: 5
@@ -32,10 +32,13 @@
 
 - name: known_hosts are registered
   known_hosts:
-    name: "{{ item.0.item }}"
+    name: "{{ _borgmatic_item_host }}"
     key: "{{ item.1 }}"
     path: "{{ borgmatic_ssh_known_hosts_file }}"
   loop: "{{ borgmatic_ssh_fingerprints.results | subelements('stdout_lines') }}"
   when: item.1 is not regex('^#.*')
+  vars:
+    _borgmatic_item_host: "{{ item.1.split(' ').0 }}"
+    _borgmatic_item_type: "{{ item.1.split(' ').1 }}"
   loop_control:
-    label: "{{ item.0.item }} {{ item.1.split(' ').1 }}"
+    label: "{{ _borgmatic_item_host }} {{ _borgmatic_item_type }}"


### PR DESCRIPTION
Some of my hosts don't use the normal port for SSH but a custom one, others don't have a resolvable host name. The management of SSH host keys simply passes the inventory name to `ssh-keyscan`. Thus you assume that the node name is equal to the host name and is reachable. Instead, the inventory could contain an `ansible_host` variable for this host. Same applies for `ansible_port`.
When specifying a non-default port to `ssh-keyscan`, its output is in the format `[hostname]:port`. Thus, the following `known_hosts` step has to look for this name. I chose to parse it from the response string instead of building it on my own.