### PR TITLE
Make borg & borgmatic binary path configurable

### DIFF
--- a/roles/borg_server/defaults/main.yml
+++ b/roles/borg_server/defaults/main.yml
@@ -3,6 +3,7 @@
 
 borg_server_user: borg
 borg_server_config_path: /etc/borg-server
+borg_server_binary_path: borg
 
 borg_server_backups_path: /var/borg-server
 borg_server_backups_set_permissions: yes

--- a/roles/borg_server/templates/authorized_keys.j2
+++ b/roles/borg_server/templates/authorized_keys.j2
@@ -1,4 +1,4 @@
 {% for host in borg_server_authorized_hosts %}
 {% set append_only = " --append-only" if (host.append_only | d(false)) else '' %}
-command="cd {{ borg_server_backups_path }}/{{ host.name }}; borg serve --restrict-to-path {{ borg_server_backups_path }}/{{ host.name }}{{ append_only }}",restrict {{ host.key }}
+command="cd {{ borg_server_backups_path }}/{{ host.name }}; {{ borg_server_binary_path }} serve --restrict-to-path {{ borg_server_backups_path }}/{{ host.name }}{{ append_only }}",restrict {{ host.key }}
 {% endfor %}

--- a/roles/borgmatic/defaults/main.yml
+++ b/roles/borgmatic/defaults/main.yml
@@ -4,6 +4,7 @@
 borgmatic_install: yes
 
 borgmatic_config_path: /etc/borgmatic
+borgmatic_binary_path: /usr/bin/borgmatic
 
 borgmatic_setup_backup: yes
 borgmatic_init_repos: yes

--- a/roles/borgmatic/templates/borgmatic.service.j2
+++ b/roles/borgmatic/templates/borgmatic.service.j2
@@ -48,4 +48,4 @@ LogRateLimitIntervalSec=0
 
 # Delay start to prevent backups running during boot. Note that systemd-inhibit requires dbus and
 # dbus-user-session to be installed.
-ExecStart=/usr/bin/borgmatic --syslog-verbosity 1
+ExecStart={{ borgmatic_binary_path }} --syslog-verbosity 1


### PR DESCRIPTION
This can be used to not use the system's installation but e.g. one in a venv