### PR TITLE
remove EOL distros, bump ansible and python to 2.18/3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ workflows:
           parallelism: 3
           matrix:
             parameters:
-              ansible-version: ["2.16", "2.17"]
-              node-python-version: ["3.7"]
+              ansible-version: ["2.17", "2.18"]
+              node-python-version: ["3.9"]
       - collection-testing/pre-commit-lint:
           name: Lint
       - collection-testing/publish-github:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Dependencies
 
 - A recent version of ansible. We test against the current and the previous major release
-- Python 3.7 or newer on remote hosts and the controller
+- Python 3.8 or newer on remote hosts
 
 ### Install via ansible-galaxy
 

--- a/roles/borg_server/README.md
+++ b/roles/borg_server/README.md
@@ -9,8 +9,8 @@ The server uses these keys to restrict hosts into a single directory where they 
 ## Requirements
 
 - The following distributions are currently supported:
-  - Ubuntu: 20.04 LTS, 22.04, 24.04 LTS
-  - Debian: 10, 11, 12
+  - Ubuntu: 22.04 LTS, 24.04 LTS
+  - Debian: 11, 12
   - There are no plans to support CentOS/RHEL-based distros right now
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 

--- a/roles/borg_server/molecule/default/molecule.yml
+++ b/roles/borg_server/molecule/default/molecule.yml
@@ -22,17 +22,6 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: borg-server-ubuntu-20
-    groups:
-      - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
-    override_command: false
-    pre_build_image: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-
   - name: borg-server-debian-12
     groups:
       - debian
@@ -48,17 +37,6 @@ platforms:
     groups:
       - debian
     image: "docker.io/geerlingguy/docker-debian11-ansible"
-    override_command: false
-    pre_build_image: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-
-  - name: borg-server-debian-10
-    groups:
-      - debian
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
     override_command: false
     pre_build_image: true
     volumes:

--- a/roles/borgmatic/README.md
+++ b/roles/borgmatic/README.md
@@ -15,7 +15,7 @@ This role can perform the following actions for you:
 - A distribution with `borgbackup` and `borgmatic` packages in its repo
     - This role supports Borgmatic versions `1.5` and newer
     - We test the following distributions, other distros may work but are unsupported:
-        - Ubuntu 20.04 LTS, 22.04, 24.04 LTS
+        - Ubuntu 22.04 LTS, 24.04 LTS
         - Debian 11, 12
 - **This role requires root access**. Make sure to run this role with `become: yes` or as the root user
 

--- a/roles/borgmatic/molecule/default/molecule.yml
+++ b/roles/borgmatic/molecule/default/molecule.yml
@@ -22,17 +22,6 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: borgmatic-ubuntu-20
-    groups:
-      - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
-    override_command: false
-    pre_build_image: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-
   - name: borgmatic-debian-12
     groups:
       - debian

--- a/roles/borgmatic/molecule/remote-repo-unmanaged-ssh/molecule.yml
+++ b/roles/borgmatic/molecule/remote-repo-unmanaged-ssh/molecule.yml
@@ -28,20 +28,6 @@ platforms:
     networks:
       - name: molecule-borgmatic
 
-  - name: borgmatic-ubuntu-20
-    groups:
-      - ubuntu
-      - clients
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
-    override_command: false
-    pre_build_image: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    networks:
-      - name: molecule-borgmatic
-
   - name: borgmatic-debian-12
     groups:
       - debian

--- a/roles/borgmatic/molecule/remote-repo/molecule.yml
+++ b/roles/borgmatic/molecule/remote-repo/molecule.yml
@@ -28,20 +28,6 @@ platforms:
     networks:
       - name: molecule-borgmatic
 
-  - name: borgmatic-ubuntu-20
-    groups:
-      - ubuntu
-      - clients
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
-    override_command: false
-    pre_build_image: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    networks:
-      - name: molecule-borgmatic
-
   - name: borgmatic-debian-12
     groups:
       - debian

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from packaging import version
 import pytest
 import yaml
 
-NODE_PYTHON_DEFAULT_VERSION = "3.6"
+NODE_PYTHON_DEFAULT_VERSION = "3.9"
 
 with open("galaxy.yml", encoding="utf-8") as f:
     GALAXY_YML = yaml.safe_load(f)


### PR DESCRIPTION
Ubuntu 20.04 and Debian 11 have reached their mainline EOL. With them removed, we can bump the minimum Python version to 3.9, allowing us to support both Ansible 2.18 and possibly 2.19